### PR TITLE
Bff proposal additional improvements

### DIFF
--- a/_adr/92/index.adoc
+++ b/_adr/92/index.adoc
@@ -105,7 +105,7 @@ We want the current microservices to stay vertical and opinionated toward a mini
 * The introduction of private data planes can introduce additional issues because of backend APIs reachability
 
 For private data plates, we know it is a known feature coming but its impact will not be done as part of this work.
-It could lead to change int he BFF pattern approached described here and to the control plane at large.
+It could lead to change in the BFF pattern approached described here and to the control plane at large.
 
 ## Dependencies
 

--- a/_adr/92/index.adoc
+++ b/_adr/92/index.adoc
@@ -104,6 +104,9 @@ We want the current microservices to stay vertical and opinionated toward a mini
 * Potential lack of control over APIs being aggregated
 * The introduction of private data planes can introduce additional issues because of backend APIs reachability
 
+For private data plates, we know it is a known feature coming but its impact will not be done as part of this work.
+It could lead to change int he BFF pattern approached described here and to the control plane at large.
+
 ## Dependencies
 
 * The new Java Kiota SDKs should be officially published

--- a/_adr/92/index.adoc
+++ b/_adr/92/index.adoc
@@ -70,7 +70,14 @@ Being it a publicly accessible service the generic service Threat model applies,
 * Circuit Breaking
 * Caching
 
-Regarding multitenancy, it can be achieved, in the first prototype by re-using the Access Token for the initial API request to issue the following requests to the backend services.
+Regarding multitenancy, it is achieved by re-using the Access Token for the initial API request to issue the following requests to the backend services.
+Access token propagation is the preferred model because:
+
+* it keeps the security model unchanged: the alternative impose a carefully hardened BFF component to avoid escalation of privilege)
+* it is similar to the usage without BFF (e.g. the UI would send the access token to each of the services)
+
+Note that it could be come more difficult if we were to embrace https://datatracker.ietf.org/doc/html/draft-ietf-oauth-dpop[sender-constrained tokens] or https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures[signed HTTP requests].
+This is a problem for later.
 
 ## Alternatives Considered / Rejected
 

--- a/_ap/19/index.adoc
+++ b/_ap/19/index.adoc
@@ -1,6 +1,6 @@
 ---
 num: 19
-title: "Toward a more unified UX: BFF"
+title: "Use a BFF component in front of our APIs to unify UX and client support"
 status: "Draft"
 authors:
   - "Andrea Peruffo"
@@ -11,7 +11,7 @@ tags: []
 
 ## Intent
 
-Define an architectural component to better decouple backend services and frontend needs offering a more cohesive UX across devices and tools (such as UI and CLI).
+Define an architectural approach to better decouple backend services and frontend needs offering a more cohesive UX across devices and tools (such as UI and CLI).
 
 ## Motivation
 
@@ -23,7 +23,7 @@ UI and CLI needs to poll information from multiple separate sources causing:
 
 ## Applicability
 
-This pattern applies when the functionality offered by frontend/CLI/etc. needs to access various APIs and do data-aggregation logic in various forms.
+This pattern applies when the functionality offered by frontend/CLI/etc. needs to access various APIs and do data aggregation logic in various forms.
 In those cases placing a frontend opinionated component in front can be an appropriate solution to speed up development and be a single source of truth for integration logic.
 
 ## Description

--- a/_ap/19/index.adoc
+++ b/_ap/19/index.adoc
@@ -12,6 +12,7 @@ tags: []
 ## Intent
 
 Define an architectural approach to better decouple backend services and frontend needs offering a more cohesive UX across devices and tools (such as UI and CLI).
+Align all application services under the same implementation of that pattern (see description).
 
 ## Motivation
 
@@ -26,11 +27,30 @@ UI and CLI needs to poll information from multiple separate sources causing:
 This pattern applies when the functionality offered by frontend/CLI/etc. needs to access various APIs and do data aggregation logic in various forms.
 In those cases placing a frontend opinionated component in front can be an appropriate solution to speed up development and be a single source of truth for integration logic.
 
+A single BFF component is planned to host the API interactions of our various application services (Kafka, Connectors, Service registry etc).
+This is a simplification choice that could be revisited if it becomes burdensome.
+Until it is, alignment is expected.
+
 ## Description
 
 Implementing a https://samnewman.io/patterns/architectural/bff/[BFF] for the backend services to better decouple and centralize the integration logic.
 
 image::with_BFF.png[Proposed Architecture]
+
+Following are key contextual information to understand the pattern and its potential limitations.
+
+Access to the underlying services will be done by propagating the original (user) access token to simplify development and to keep the security model similar to the current architecture.
+See ADR 91 for more details.
+
+The implementation choice went for a custom REST endpoint implementation as opposed to using GraphQL.
+GraphQL is a popular technology built to address this or a similar set of use cases.
+The team's experience lead tot he choice of a custom REST endpoint but could be revisited by this or another team.
+
+The API exposed will not be considered a stable contract usable by customers.
+Only its usage through sanctioned clients (UI, CLI, SDK) are going to be supported.
+This can be revisited with experience.
+
+This proposal has not explored in detail the impact of private data plane clusters and could be impacted by that architectural evolution.
 
 ## Participants
 


### PR DESCRIPTION
It closes on some tactical subjects in the ADR (see individual commits)

It make the Architecture Pattern more explicit and concrete.
This change has two objectives:
1. Make the AP more concrete and clearer to teams that will read it in
   the future and the constraints it puts on them.
   In particular, limits and choices are detailed
2. Clarify that GraphQL was not chosen but keep the door open to a
   future use.